### PR TITLE
Upgrade json dependency in view of CVE-2020-10663

### DIFF
--- a/mandrill-api.gemspec
+++ b/mandrill-api.gemspec
@@ -7,6 +7,6 @@ Gem::Specification.new do |s|
     s.email = 'community@mandrill.com'
     s.files = ['lib/mandrill.rb', 'lib/mandrill/api.rb', 'lib/mandrill/errors.rb']
     s.homepage = 'https://bitbucket.org/mailchimp/mandrill-api-ruby/'
-    s.add_dependency 'json', '>= 1.7.7'
+    s.add_dependency 'json', '>= 2.3.0'
     s.add_dependency 'excon'
 end


### PR DESCRIPTION
Require JSON 2.3.0, to mitigate https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/